### PR TITLE
refactor: svg 로드 컴포넌트화

### DIFF
--- a/src/components/common/ImgSwiper/index.tsx
+++ b/src/components/common/ImgSwiper/index.tsx
@@ -1,11 +1,11 @@
 import { Image } from '@interfaces/diaryTypes';
-import tape2 from '@assets/icons/tape2.svg';
-import tape3 from '@assets/icons/tape3.svg';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import * as S from './styles.css';
 import './sliderBtnStyle.css';
+import { ReactComponent as Tape3 } from '@assets/icons/tape3.svg';
+import { ReactComponent as Tape2 } from '@assets/icons/tape2.svg';
 
 interface ImgSwiperProps {
   imgList: Image[];
@@ -29,8 +29,8 @@ const ImgSwiper = ({ imgList }: ImgSwiperProps) => {
               <img className={S.img} src={img.url} alt="img"></img>
             </div>
             <div className={S.cover}>
-              <img src={tape3} className={S.tape1} alt="tape"></img>
-              <img src={tape2} className={S.tape2} alt="tape"></img>
+              <Tape3 className={S.tape1} />
+              <Tape2 className={S.tape2} />
             </div>
           </div>
         );


### PR DESCRIPTION
초기 전체 렌더링이 살짝 늦어질 수 있으나
svg만 나중에 로드되는걸 막아 사용자 경험을 높임